### PR TITLE
[Locales] Fix french translation

### DIFF
--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -25,7 +25,7 @@
     "downloads": "Téléchargements",
     "search_results": "Résultats de la recherche",
     "settings": "Paramètres",
-    "home": "Maison"
+    "home": "Accueil"
   },
   "bottom_panel": {
     "no_downloads_in_progress": "Aucun téléchargement en cours",


### PR DESCRIPTION
Hi, while reviewing a PR I noticed that in the french translation, the home screen is translated "meson", which would be correct if you were talking about a home as the building.
I'm not a french native speaker but that looked off to me so i did some research.
Apparently in software development the home screen is referred as "Accueil".

Fix #80